### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,11 +123,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1666281610,
-        "narHash": "sha256-RLoLNYefKHk3Eip/O78sbsAUlRUZXONEj9mffkA+wr0=",
+        "lastModified": 1666901616,
+        "narHash": "sha256-InzIpkmf0aBw/s/VwaGyHh3Ie99OJDC+bjJfL1nQIGw=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "8a97902942fdaac6398a32e405d5b1bb04d6a3d0",
+        "rev": "e679e7c6a1b9372afcde18d11ac18159d493682c",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666249138,
-        "narHash": "sha256-CzK8NA8xEMKAhvHXB8UMODckcH97sZXm6lziKNWLv0M=",
+        "lastModified": 1666867875,
+        "narHash": "sha256-3nD7iQXd/J6KjkT8IjozTuA5p8qjiLKTxvOUmH+AzNM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44fc3cb097324c9f9f93313dd3f103e78d722968",
+        "rev": "c132d0837dfb9035701dcd8fc91786c605c855c3",
         "type": "github"
       },
       "original": {
@@ -154,23 +154,23 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-rA911ozyDcfCBDr7PtRiKVgvHfqUAlKOhxBuiDuhxYg=",
+        "narHash": "sha256-TTiUcQw+Mt+qfUEykkAmI8lhfspi8jhlWZ7VKSF+2rg=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1664286682,
-        "narHash": "sha256-OBdpqW2zpwYF/JWUk013rbMdIC3R17ynX78tQPbfHNw=",
+        "lastModified": 1666251292,
+        "narHash": "sha256-8U27YbBwITbnVcC/PBQWsOP2EkpBMfKlD82Fb4NBOcc=",
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "rev": "bc0c4989f664ff262d3ab39cad9dc0f6f1c10017",
+        "rev": "47f5444116df877b22cd262bfd01d0874f370e8a",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666389035,
-        "narHash": "sha256-BX+U9l+SNLCigBhprxYW26Tz1pVu+6Ab8zW1HRU+PcE=",
+        "lastModified": 1666996884,
+        "narHash": "sha256-hQh/TOP72Y/qJygCNGk2UCfIoYytBKUiBZzEnQSX8Ig=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "520df33879c5693caeefb9b3347b530e83dcc540",
+        "rev": "7f4b27bf9e7a8302b7662e37514d037f48fef4f4",
         "type": "github"
       },
       "original": {
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666148516,
-        "narHash": "sha256-pFgSJzUFsnCTulIzhn3HHImaZpqlMxAvXTrhg0qlMOE=",
+        "lastModified": 1666839029,
+        "narHash": "sha256-gmSmf3bDS9oR4OHsvKHEErqje228XXP22uKIQWZj4Jo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3e41700ab6f585b9569112ee7516c74f8d072989",
+        "rev": "c095030cf6c84e304f867ad066d8d5b051131af5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'indexyz':
    'github:X01A/nixos/8a97902942fdaac6398a32e405d5b1bb04d6a3d0' (2022-10-20)
  → 'github:X01A/nixos/e679e7c6a1b9372afcde18d11ac18159d493682c' (2022-10-27)
• Updated input 'indexyz/npmlock2nix':
    'github:serokell/nix-npm-buildpackage/bc0c4989f664ff262d3ab39cad9dc0f6f1c10017' (2022-09-27)
  → 'github:serokell/nix-npm-buildpackage/47f5444116df877b22cd262bfd01d0874f370e8a' (2022-10-20)
• Updated input 'indexyz/rust-overlay':
    'github:oxalica/rust-overlay/3e41700ab6f585b9569112ee7516c74f8d072989' (2022-10-19)
  → 'github:oxalica/rust-overlay/c095030cf6c84e304f867ad066d8d5b051131af5' (2022-10-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/44fc3cb097324c9f9f93313dd3f103e78d722968' (2022-10-20)
  → 'github:NixOS/nixpkgs/c132d0837dfb9035701dcd8fc91786c605c855c3' (2022-10-27)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3705.44fc3cb0973/nixexprs.tar.xz?narHash=sha256-rA911ozyDcfCBDr7PtRiKVgvHfqUAlKOhxBuiDuhxYg='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz?narHash=sha256-TTiUcQw+Mt+qfUEykkAmI8lhfspi8jhlWZ7VKSF+2rg='
• Updated input 'nur':
    'github:nix-community/NUR/520df33879c5693caeefb9b3347b530e83dcc540' (2022-10-21)
  → 'github:nix-community/NUR/7f4b27bf9e7a8302b7662e37514d037f48fef4f4' (2022-10-28)