### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665996265,
-        "narHash": "sha256-/k9og6LDBQwT+f/tJ5ClcWiUl8kCX5m6ognhsAxOiCY=",
+        "lastModified": 1667469118,
+        "narHash": "sha256-2YrDEmeYKCDOCuDDrjHoaUOVO3hyh9cIrWAJET1HPg8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b81e128fc053ab3159d7b464d9b7dedc9d6a6891",
+        "rev": "d78b3488a76d251701ab58a9b7f0dd092b806c1e",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1666901616,
-        "narHash": "sha256-InzIpkmf0aBw/s/VwaGyHh3Ie99OJDC+bjJfL1nQIGw=",
+        "lastModified": 1667188245,
+        "narHash": "sha256-IFaG8q39UbPbxJSIBsBx53bONiwlURJ0CbAknBKgMRc=",
         "owner": "X01A",
         "repo": "nixos",
-        "rev": "e679e7c6a1b9372afcde18d11ac18159d493682c",
+        "rev": "6a74abb527f71fcb07f7acec63d6757ebfd4340a",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666867875,
-        "narHash": "sha256-3nD7iQXd/J6KjkT8IjozTuA5p8qjiLKTxvOUmH+AzNM=",
+        "lastModified": 1667420999,
+        "narHash": "sha256-NDz83NKuuEuonbhC5HnfhUpZsJQGmAWJr22snKGfhKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c132d0837dfb9035701dcd8fc91786c605c855c3",
+        "rev": "4f09cfce9c1d54fb56b65125061a632849de1a49",
         "type": "github"
       },
       "original": {
@@ -154,13 +154,13 @@
     },
     "nixpkgs-channel": {
       "locked": {
-        "narHash": "sha256-TTiUcQw+Mt+qfUEykkAmI8lhfspi8jhlWZ7VKSF+2rg=",
+        "narHash": "sha256-BknUF7jM1Y97fX5R/mZSs9+Ift1+1kgybYvgv2uQhtU=",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3954.4f09cfce9c1/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/22.05/nixos-22.05.3954.4f09cfce9c1/nixexprs.tar.xz"
       }
     },
     "npmlock2nix": {
@@ -181,11 +181,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1666996884,
-        "narHash": "sha256-hQh/TOP72Y/qJygCNGk2UCfIoYytBKUiBZzEnQSX8Ig=",
+        "lastModified": 1667549886,
+        "narHash": "sha256-ZsPCOboM+ZjkoCS3KebSua8eZTOsK0gMx0qcI3G8gXo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7f4b27bf9e7a8302b7662e37514d037f48fef4f4",
+        "rev": "5353096ab815fb2ee0e5091d723e698150af660f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
-    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz";
+    nixpkgs-channel.url = "https://releases.nixos.org/nixos/22.05/nixos-22.05.3954.4f09cfce9c1/nixexprs.tar.xz";
 
     home-manager.url = "github:nix-community/home-manager/release-22.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/b81e128fc053ab3159d7b464d9b7dedc9d6a6891' (2022-10-17)
  → 'github:nix-community/home-manager/d78b3488a76d251701ab58a9b7f0dd092b806c1e' (2022-11-03)
• Updated input 'indexyz':
    'github:X01A/nixos/e679e7c6a1b9372afcde18d11ac18159d493682c' (2022-10-27)
  → 'github:X01A/nixos/6a74abb527f71fcb07f7acec63d6757ebfd4340a' (2022-10-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c132d0837dfb9035701dcd8fc91786c605c855c3' (2022-10-27)
  → 'github:NixOS/nixpkgs/4f09cfce9c1d54fb56b65125061a632849de1a49' (2022-11-02)
• Updated input 'nixpkgs-channel':
    'https://releases.nixos.org/nixos/22.05/nixos-22.05.3848.c132d0837df/nixexprs.tar.xz?narHash=sha256-TTiUcQw+Mt+qfUEykkAmI8lhfspi8jhlWZ7VKSF+2rg='
  → 'https://releases.nixos.org/nixos/22.05/nixos-22.05.3954.4f09cfce9c1/nixexprs.tar.xz?narHash=sha256-BknUF7jM1Y97fX5R%2fmZSs9+Ift1+1kgybYvgv2uQhtU='
• Updated input 'nur':
    'github:nix-community/NUR/7f4b27bf9e7a8302b7662e37514d037f48fef4f4' (2022-10-28)
  → 'github:nix-community/NUR/5353096ab815fb2ee0e5091d723e698150af660f' (2022-11-04)