### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670461440,
-        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
+        "lastModified": 1671122953,
+        "narHash": "sha256-SVWmiyX2wx6BAxo4zMfRqDgFoWf4d3Vx1MgG/Vo4jL4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "rev": "0152de25d49dc16883b65f3e29cfea8d32f68956",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1670560288,
-        "narHash": "sha256-3TylYeaVeNkuIcyvdwCy/D1k723CDRqUgViRZCAdsGw=",
+        "lastModified": 1671164982,
+        "narHash": "sha256-FUUCvNkl1h6REwdZwcDJwG40KlUR0PxZBnYsjLwgqVk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "557e831973c5c9ce04e548e0672cad6ead61bbdd",
+        "rev": "f3916354fd1062404802f6a95fb8e1fd02392118",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670253546,
-        "narHash": "sha256-3pjBz6Q7Bf/JsD2rzJFBQNrCBKlvsbKZNInyQY3Qj2M=",
+        "lastModified": 1670590806,
+        "narHash": "sha256-R4PBoqD+IsHZzG0XKP11FxMtIh1EwC092etnHrVY3bg=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "6c0fcc154ff7af7980eda9d4490e977fcff60331",
+        "rev": "b3bf69ae0f17bfb8b81d755c3fd41121bbe07fc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/04a75b2eecc0acf6239acf9dd04485ff8d14f425' (2022-12-08)
  → 'github:NixOS/nixpkgs/0152de25d49dc16883b65f3e29cfea8d32f68956' (2022-12-15)
• Updated input 'nur':
    'github:nix-community/NUR/557e831973c5c9ce04e548e0672cad6ead61bbdd' (2022-12-09)
  → 'github:nix-community/NUR/f3916354fd1062404802f6a95fb8e1fd02392118' (2022-12-16)
• Updated input 'slaier':
    'github:slaier/nur-packages/6c0fcc154ff7af7980eda9d4490e977fcff60331' (2022-12-05)
  → 'github:slaier/nur-packages/b3bf69ae0f17bfb8b81d755c3fd41121bbe07fc6' (2022-12-09)