### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
     },
     "nix-index-database": {
       "locked": {
-        "lastModified": 1670730290,
-        "narHash": "sha256-wNeXBgQM82YPQCE4AoLV/5K0TeeViy6w1U4R4V0azek=",
+        "lastModified": 1671334453,
+        "narHash": "sha256-3dSt0yH6TxTJ96G5y7YXSoZ2kMlhP99x0BnfX+1G2JA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b23c44355693a56665d704650cae08612a8c88ce",
+        "rev": "ce6215b60223f465c1d694547f880566868a2107",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671122953,
-        "narHash": "sha256-SVWmiyX2wx6BAxo4zMfRqDgFoWf4d3Vx1MgG/Vo4jL4=",
+        "lastModified": 1671525405,
+        "narHash": "sha256-MEgNxm/oRt5w4ycMENewfZQKOak0ixmjVPfXM96N1FA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0152de25d49dc16883b65f3e29cfea8d32f68956",
+        "rev": "cbe419ed4c8f98bd82d169c321d339ea30904f1f",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1671164982,
-        "narHash": "sha256-FUUCvNkl1h6REwdZwcDJwG40KlUR0PxZBnYsjLwgqVk=",
+        "lastModified": 1671770953,
+        "narHash": "sha256-PbrqebO/RUT/C2YbWs2g4dcJUx/Y+znSwdwKyOAzZPo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f3916354fd1062404802f6a95fb8e1fd02392118",
+        "rev": "3a5f3717d0b71ecdda7658e3bd54bc9ebeb408d5",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670590806,
-        "narHash": "sha256-R4PBoqD+IsHZzG0XKP11FxMtIh1EwC092etnHrVY3bg=",
+        "lastModified": 1671195862,
+        "narHash": "sha256-yvFmgtund/hWiYvOzJmIeYXJu+Vs4+HM/Ze062C4c+o=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "b3bf69ae0f17bfb8b81d755c3fd41121bbe07fc6",
+        "rev": "634c36a53b5a68c498dc4aa50e443ab3c33697bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/b23c44355693a56665d704650cae08612a8c88ce' (2022-12-11)
  → 'github:Mic92/nix-index-database/ce6215b60223f465c1d694547f880566868a2107' (2022-12-18)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0152de25d49dc16883b65f3e29cfea8d32f68956' (2022-12-15)
  → 'github:NixOS/nixpkgs/cbe419ed4c8f98bd82d169c321d339ea30904f1f' (2022-12-20)
• Updated input 'nur':
    'github:nix-community/NUR/f3916354fd1062404802f6a95fb8e1fd02392118' (2022-12-16)
  → 'github:nix-community/NUR/3a5f3717d0b71ecdda7658e3bd54bc9ebeb408d5' (2022-12-23)
• Updated input 'slaier':
    'github:slaier/nur-packages/b3bf69ae0f17bfb8b81d755c3fd41121bbe07fc6' (2022-12-09)
  → 'github:slaier/nur-packages/634c36a53b5a68c498dc4aa50e443ab3c33697bc' (2022-12-16)