### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1674962474,
-        "narHash": "sha256-qEXdgW5fnMSdQwP1zQYa0fVtI0f3G1f2qNRjUEherCs=",
+        "lastModified": 1675567746,
+        "narHash": "sha256-huugg+7ok2VjmoLhkT+mAcw6iVK+hOqrYV0jMMD4EpQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a385f6192f5471c4cebeeb0d2e966b5ccf123df5",
+        "rev": "3880fa89727c622ae4674a2b6169c81112b43cf4",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1675237434,
-        "narHash": "sha256-YoFR0vyEa1HXufLNIFgOGhIFMRnY6aZ0IepZF5cYemo=",
+        "lastModified": 1675918889,
+        "narHash": "sha256-hy7re4F9AEQqwZxubct7jBRos6md26bmxnCjxf5utJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "285b3ff0660640575186a4086e1f8dc0df2874b5",
+        "rev": "49efda9011e8cdcd6c1aad30384cb1dc230c82fe",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1675401726,
-        "narHash": "sha256-SOG0unCuN8OwqALj0yHOfyuQcy1XaMlSLljgo3xqABw=",
+        "lastModified": 1676011760,
+        "narHash": "sha256-lIX7eGzysyUDn6UJAPKihBG2TBVu0L0cFETD1PMXYOo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "48a5b6e224fc2ecc023d1655c1da9bf3105ba1ff",
+        "rev": "5b7978566c3e767c0b533290b7d3edfe630eaec8",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675086281,
-        "narHash": "sha256-KQTXTYVJ9QU+LnJEJ+bcyD7bXxYJ+wvb2g773xsEqh4=",
+        "lastModified": 1675422830,
+        "narHash": "sha256-UiOgsm72PHIOf3ylV1OdZZfuPSORGOUuYBsbEjDFO3A=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "43169872c69f8e4c1d1818ef51c9100f6effdd72",
+        "rev": "864b0dddc312ffc48dcc11c5e87d9eacc08aea1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/a385f6192f5471c4cebeeb0d2e966b5ccf123df5' (2023-01-29)
  → 'github:Mic92/nix-index-database/3880fa89727c622ae4674a2b6169c81112b43cf4' (2023-02-05)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/285b3ff0660640575186a4086e1f8dc0df2874b5' (2023-02-01)
  → 'github:NixOS/nixpkgs/49efda9011e8cdcd6c1aad30384cb1dc230c82fe' (2023-02-09)
• Updated input 'nur':
    'github:nix-community/NUR/48a5b6e224fc2ecc023d1655c1da9bf3105ba1ff' (2023-02-03)
  → 'github:nix-community/NUR/5b7978566c3e767c0b533290b7d3edfe630eaec8' (2023-02-10)
• Updated input 'slaier':
    'github:slaier/nur-packages/43169872c69f8e4c1d1818ef51c9100f6effdd72' (2023-01-30)
  → 'github:slaier/nur-packages/864b0dddc312ffc48dcc11c5e87d9eacc08aea1f' (2023-02-03)