### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1676172252,
-        "narHash": "sha256-Q5yJPpgbvOTgB0NQTJmlx3di1Sj5QQhSrjv38u6MzsQ=",
+        "lastModified": 1676778053,
+        "narHash": "sha256-5/NghN1FCFpwCWp6Q3W4Of3keKYx/RgCNFuUmk6YmAA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "89e3b689e0ae9bac4c6cdc24d1085d81baeebde4",
+        "rev": "688adea5ecff698a49461f77d649cc854b805dbc",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1676375384,
-        "narHash": "sha256-6HI3jZiuJX+KLz05cocYy2mBAWlISEKHU84ftYfxHZ8=",
+        "lastModified": 1677075010,
+        "narHash": "sha256-X+UmR1AkdR//lPVcShmLy8p1n857IGf7y+cyCArp8bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c43f676c938662072772339be6269226c77b51b8",
+        "rev": "c95bf18beba4290af25c60cbaaceea1110d0f727",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1676619352,
-        "narHash": "sha256-a9pQbtOcUYS9boD6+lQqPe0WzME0x8yzZk365w9XGbM=",
+        "lastModified": 1677224679,
+        "narHash": "sha256-5B0GcCx9cXtxWJSQE+9O6jEqD43nESqujyhmrHis9Cg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d2d70316f27384cf53e0f3c6cf2fd73e4744555a",
+        "rev": "72c71ff18e115a8439295b02c707a847d0413198",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676119248,
-        "narHash": "sha256-JjfaxyszEDMBSvnTO5fUfbsQyHW5V+/U8NOPhwn5cSw=",
+        "lastModified": 1676635818,
+        "narHash": "sha256-lzThyyTl/2A6cVQK7xIaJQtShwZ7tBfedFKn+yEQWhE=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "04bcf7cbaad224812882b26a250f0d768a666075",
+        "rev": "f824f07907bd87e0c745fb8762116f438f5e4b51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/89e3b689e0ae9bac4c6cdc24d1085d81baeebde4' (2023-02-12)
  → 'github:Mic92/nix-index-database/688adea5ecff698a49461f77d649cc854b805dbc' (2023-02-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/c43f676c938662072772339be6269226c77b51b8' (2023-02-14)
  → 'github:NixOS/nixpkgs/c95bf18beba4290af25c60cbaaceea1110d0f727' (2023-02-22)
• Updated input 'nur':
    'github:nix-community/NUR/d2d70316f27384cf53e0f3c6cf2fd73e4744555a' (2023-02-17)
  → 'github:nix-community/NUR/72c71ff18e115a8439295b02c707a847d0413198' (2023-02-24)
• Updated input 'slaier':
    'github:slaier/nur-packages/04bcf7cbaad224812882b26a250f0d768a666075' (2023-02-11)
  → 'github:slaier/nur-packages/f824f07907bd87e0c745fb8762116f438f5e4b51' (2023-02-17)