### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678285456,
-        "narHash": "sha256-2rIk5OFGQmoFX1MWntKGPVCZvy5yQMX3ZCYz7i8+yb0=",
+        "lastModified": 1678673526,
+        "narHash": "sha256-tMI1inGT9u4KWQml0w30dhWqQPlth1e9K/68sfDkEQA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0be47978de5cfd729a79c3f57ace4c86364ff45",
+        "rev": "74e0b590c0c8eb99548b8db40c323ff61a2f37c4",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1678095956,
-        "narHash": "sha256-I8o9R8X7SkqObDWfhBogUNtwAC17qERK97g5LVsHGpA=",
+        "lastModified": 1678900860,
+        "narHash": "sha256-whR4CNeKaXFi2o+oZBj7o4bV+sw8fAHW9s1Dk+JPZU0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4644dcf60506c29ed2cbcd530652b1a1835024b2",
+        "rev": "fb4949a2ddf4dcfb53c0eaf01334522309045471",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1678230755,
-        "narHash": "sha256-SFAXgNjNTXzcAideXcP0takfUGVft/VR5CACmYHg+Fc=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7cc81913bb3cd1ef05ed0ece048b773e1839e51",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1678434006,
-        "narHash": "sha256-vYiRVsB2CZ17aBYONDa2ik/3NSmkvjIPmkPuO+hkUlw=",
+        "lastModified": 1679039592,
+        "narHash": "sha256-YCPrqC9PTNU6HOi/VLQRXGX5NjPidHnL+nqKdf1AB/8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "635206085c5a429d5459b955e84e0f29242313a1",
+        "rev": "eb7ad2ad2734e3849fd74fab626ef6ad06122960",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678106405,
-        "narHash": "sha256-fOhCrNrIyoUJD4FC3Bc3gqVap1G7+HADH7O5eMOVBLk=",
+        "lastModified": 1678447107,
+        "narHash": "sha256-V7sCQS8L5gDLrCkf5Lm+pUOVgy0XZ/peE9uBudgX9EM=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "9820bfe776c67d3ec8ec1bce5ae8968b731a7375",
+        "rev": "ca021617a3c83d6f35dddac686eb78a2f90d3a8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/3db36a8b464d0c4532ba1c7dda728f4576d6d073' (2023-02-13)
  → 'github:numtide/flake-utils/93a2b84fc4b70d9e089d029deacc3583435c2ed6' (2023-03-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b0be47978de5cfd729a79c3f57ace4c86364ff45' (2023-03-08)
  → 'github:nix-community/home-manager/74e0b590c0c8eb99548b8db40c323ff61a2f37c4' (2023-03-13)
• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/4644dcf60506c29ed2cbcd530652b1a1835024b2' (2023-03-06)
  → 'github:Mic92/nix-index-database/fb4949a2ddf4dcfb53c0eaf01334522309045471' (2023-03-15)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a7cc81913bb3cd1ef05ed0ece048b773e1839e51' (2023-03-07)
  → 'github:NixOS/nixpkgs/9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8' (2023-03-15)
• Updated input 'nur':
    'github:nix-community/NUR/635206085c5a429d5459b955e84e0f29242313a1' (2023-03-10)
  → 'github:nix-community/NUR/eb7ad2ad2734e3849fd74fab626ef6ad06122960' (2023-03-17)
• Updated input 'slaier':
    'github:slaier/nur-packages/9820bfe776c67d3ec8ec1bce5ae8968b731a7375' (2023-03-06)
  → 'github:slaier/nur-packages/ca021617a3c83d6f35dddac686eb78a2f90d3a8b' (2023-03-10)