### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678673526,
+        "lastModified": 1679067101,
         "narHash": "sha256-tMI1inGT9u4KWQml0w30dhWqQPlth1e9K/68sfDkEQA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74e0b590c0c8eb99548b8db40c323ff61a2f37c4",
+        "rev": "9154cd519a8942728038819682d6b3ff33f321bb",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1678900860,
-        "narHash": "sha256-whR4CNeKaXFi2o+oZBj7o4bV+sw8fAHW9s1Dk+JPZU0=",
+        "lastModified": 1679224439,
+        "narHash": "sha256-QkvcuC4b67FUkkxlMsLTMPbwoD7yZr0UvJpu6jkFuLo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "fb4949a2ddf4dcfb53c0eaf01334522309045471",
+        "rev": "2f5e6e915d70c04d673a8930f94591595c73eb84",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1679472241,
+        "narHash": "sha256-VK2YDic2NjPvfsuneJCLIrWS38qUfoW8rLLimx0rWXA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "9ef6e7727f4c31507627815d4f8679c5841efb00",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1679039592,
-        "narHash": "sha256-YCPrqC9PTNU6HOi/VLQRXGX5NjPidHnL+nqKdf1AB/8=",
+        "lastModified": 1679636577,
+        "narHash": "sha256-VITq8l3SCnw/MBuve5VX1SNHcamrYOdGGvHPMwX8HsI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "eb7ad2ad2734e3849fd74fab626ef6ad06122960",
+        "rev": "fc32207b8e7def548d5f5c1acb010f8b59df16d4",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678447107,
-        "narHash": "sha256-V7sCQS8L5gDLrCkf5Lm+pUOVgy0XZ/peE9uBudgX9EM=",
+        "lastModified": 1679147122,
+        "narHash": "sha256-jopnuqkDClLk2XiCzjxdhlEYIjVpMzJJ1O5c3H+X+Ps=",
         "owner": "slaier",
         "repo": "nur-packages",
-        "rev": "ca021617a3c83d6f35dddac686eb78a2f90d3a8b",
+        "rev": "74a79b7a951fa4d05c8c1d97343f988855706607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/74e0b590c0c8eb99548b8db40c323ff61a2f37c4' (2023-03-13)
  → 'github:nix-community/home-manager/9154cd519a8942728038819682d6b3ff33f321bb' (2023-03-17)
• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/fb4949a2ddf4dcfb53c0eaf01334522309045471' (2023-03-15)
  → 'github:Mic92/nix-index-database/2f5e6e915d70c04d673a8930f94591595c73eb84' (2023-03-19)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8' (2023-03-15)
  → 'github:NixOS/nixpkgs/9ef6e7727f4c31507627815d4f8679c5841efb00' (2023-03-22)
• Updated input 'nur':
    'github:nix-community/NUR/eb7ad2ad2734e3849fd74fab626ef6ad06122960' (2023-03-17)
  → 'github:nix-community/NUR/fc32207b8e7def548d5f5c1acb010f8b59df16d4' (2023-03-24)
• Updated input 'slaier':
    'github:slaier/nur-packages/ca021617a3c83d6f35dddac686eb78a2f90d3a8b' (2023-03-10)
  → 'github:slaier/nur-packages/74a79b7a951fa4d05c8c1d97343f988855706607' (2023-03-18)