### PR TITLE
nix(deps): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1680776469,
+        "narHash": "sha256-3CXUDK/3q/kieWtdsYpDOBJw3Gw4Af6x+2EiSnIkNQw=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "411e8764155aa9354dbcd6d5faaeb97e9e3dce24",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680361221,
-        "narHash": "sha256-AGFgi7BTEDKRGhD+5QDRjru2dbVeJqZHpnXqczmoeL4=",
+        "lastModified": 1680726606,
+        "narHash": "sha256-xaWjEhtVLOe5WZKp234pUxeK8CW0/cJNKcUPmxrvRoM=",
         "owner": "nix-community",
         "repo": "haumea",
-        "rev": "31382d9d956e8bb4d57535c4c373a78b67beeaf4",
+        "rev": "abc84235524004a26acd8c93dae8b9470292e4f4",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679738842,
-        "narHash": "sha256-CvqRbsyDW756EskojZptDU590rez29RcHDV3ezoze08=",
+        "lastModified": 1680555990,
+        "narHash": "sha256-Tu/i5sd0hk4c4VtWO8XpY3c9KmHDcOWF5Y2GSCh3LXA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83110c259889230b324bb2d35bef78bf5f214a1f",
+        "rev": "d6f3ba090ed090ae664ab5bac329654093aae725",
         "type": "github"
       },
       "original": {
@@ -130,11 +130,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1680122840,
-        "narHash": "sha256-zCQ/9iFHzCW5JMYkkHMwgK1/1/kTMgCMHq4THPINpAU=",
+        "lastModified": 1680665430,
+        "narHash": "sha256-MTVhTukwza1Jlq2gECITZPFnhROmylP2uv3O3cSqQCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a575c243c23e2851b78c00e9fa245232926ec32f",
+        "rev": "5233fd2ba76a3accb5aaa999c00509a11fd0793c",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1680245128,
-        "narHash": "sha256-nJAYvN5XwwGKsjbxm/ZArhvRQGDqnm0QE+Tgh17vbqU=",
+        "lastModified": 1680852267,
+        "narHash": "sha256-dGDlh7IjQxEje+Q4LaY4UeWRJlcHGGhwkGdrj4v7MI4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8ab2dd4c719df937f6f86b5ddfbee00ed993c9b",
+        "rev": "eb6ad3bc78100c86442a609ce9f5b410a605ffb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/93a2b84fc4b70d9e089d029deacc3583435c2ed6' (2023-03-15)
  → 'github:numtide/flake-utils/411e8764155aa9354dbcd6d5faaeb97e9e3dce24' (2023-04-06)
• Updated input 'haumea':
    'github:nix-community/haumea/31382d9d956e8bb4d57535c4c373a78b67beeaf4' (2023-04-01)
  → 'github:nix-community/haumea/abc84235524004a26acd8c93dae8b9470292e4f4' (2023-04-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/83110c259889230b324bb2d35bef78bf5f214a1f' (2023-03-25)
  → 'github:nix-community/home-manager/d6f3ba090ed090ae664ab5bac329654093aae725' (2023-04-03)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/a575c243c23e2851b78c00e9fa245232926ec32f' (2023-03-29)
  → 'github:NixOS/nixpkgs/5233fd2ba76a3accb5aaa999c00509a11fd0793c' (2023-04-05)
• Updated input 'nur':
    'github:nix-community/NUR/d8ab2dd4c719df937f6f86b5ddfbee00ed993c9b' (2023-03-31)
  → 'github:nix-community/NUR/eb6ad3bc78100c86442a609ce9f5b410a605ffb8' (2023-04-07)